### PR TITLE
Replace println with taoensso.timbre/trace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
                  [http-kit "2.2.0"]
                  [cheshire "5.8.0"]
                  [stylefruits/gniazdo "1.0.1"]
-                 [org.clojure/core.async "0.3.443"]]
+                 [org.clojure/core.async "0.3.443"]
+                 [com.taoensso/timbre "4.10.0"]]
   :plugins [[lein-codox "0.10.3"]]
   :codox {:output-path "docs/api"
           :metadata {:doc/format :markdown}})

--- a/src/clj_chrome_devtools/automation.clj
+++ b/src/clj_chrome_devtools/automation.clj
@@ -8,6 +8,7 @@
             [clj-chrome-devtools.commands.network :as network]
             [clj-chrome-devtools.events :as events]
             [clj-chrome-devtools.impl.connection :as connection]
+            [taoensso.timbre :as log]
             [clojure.core.async :as async :refer [go-loop go <!! <!]]
             [clojure.java.io :as io]
             [clojure.string :as str]
@@ -98,7 +99,7 @@
     (go-loop [v (<! ch)]
       (when v
         (let [root (:root (dom/get-document connection {}))]
-          (println "Document updated, new root: " root)
+          (log/trace "Document updated, new root: " root)
           (reset! root-atom root))
         (recur (<! ch))))
     (->Automation connection root-atom)))

--- a/src/clj_chrome_devtools/automation/fixture.clj
+++ b/src/clj_chrome_devtools/automation/fixture.clj
@@ -6,7 +6,8 @@
             [clojure.java.shell :as sh]
             [clojure.string :as str]
             [clj-chrome-devtools.impl.connection :as connection]
-            [org.httpkit.client :as http]))
+            [org.httpkit.client :as http]
+            [taoensso.timbre :as log]))
 
 (def possible-chrome-binaries
   ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
@@ -43,9 +44,9 @@
       (finally (.close s)))))
 
 (defn launch-chrome [binary-path remote-debugging-port options]
-  (println "Launching Chrome headless, binary: " binary-path
-           ", remote debugging port: " remote-debugging-port
-           ", options: " (pr-str options))
+  (log/trace "Launching Chrome headless, binary: " binary-path
+             ", remote debugging port: " remote-debugging-port
+             ", options: " (pr-str options))
   (let [args (remove nil?
                      [binary-path
                       (when (:headless? options) "--headless")

--- a/src/clj_chrome_devtools/impl/connection.clj
+++ b/src/clj_chrome_devtools/impl/connection.clj
@@ -5,7 +5,8 @@
             [cheshire.core :as cheshire]
             [clj-chrome-devtools.impl.util :refer [camel->clojure]]
             [clojure.core.async :as async]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [taoensso.timbre :as log]))
 
 (defrecord Connection [ws-connection requests event-chan event-pub])
 
@@ -28,7 +29,6 @@
         event {:domain domain
                :event event
                :params (:params msg)}]
-    ;(println "PUBLISH: " event)
     (async/go
       (async/>! event-chan event))))
 
@@ -51,8 +51,8 @@
         ;; This is an event
         (publish-event event-chan json-msg)))
     (catch Throwable t
-      (println "Exception in devtools WebSocket receive, msg: " msg
-               ", throwable: " t))))
+      (log/error "Exception in devtools WebSocket receive, msg: " msg
+                 ", throwable: " t))))
 
 (defn- fetch-ws-debugger-url [host port]
   (let [response @(http/get (str "http://" host ":" port "/json/list"))


### PR DESCRIPTION
I'm hesitant to create a PR that adds a dependency, but consider this a starting point.

If you'd prefer just to remove the `println` calls or use another logging library (such as clojure.tools.logging), just let me know.