### PR TITLE
Enable launching Chrome without sandbox

### DIFF
--- a/src/clj_chrome_devtools/automation/fixture.clj
+++ b/src/clj_chrome_devtools/automation/fixture.clj
@@ -46,6 +46,7 @@
   (let [args (remove nil?
                      [binary-path
                       (when (:headless? options) "--headless")
+                      (when (:no-sandbox? options) "--no-sandbox")
                       "--disable-gpu"
                       (str "--remote-debugging-port=" remote-debugging-port)])]
     (.exec (Runtime/getRuntime)


### PR DESCRIPTION
In many environments, AWS CodeBuild for one, Leiningen is run as a root user by default. Launching Chrome as root requires the "no-sanbox" switch to be turned on (apparently because of security reasons). Therefore being able to give the "build-and-test" function and the fixture the option to run Chrome with the sandbox turned off would be handy.