### PR TITLE
Fixes #14 by not caching root-node id

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,5 @@
+{:deps {http-kit               {:mvn/version "2.2.0"}
+        cheshire               {:mvn/version "5.8.0"}
+        stylefruits/gniazdo    {:mvn/version "1.0.1"}
+        org.clojure/core.async {:mvn/version "0.4.474"}
+        com.taoensso/timbre    {:mvn/version "4.10.0"}}}

--- a/src/clj_chrome_devtools/automation.clj
+++ b/src/clj_chrome_devtools/automation.clj
@@ -156,11 +156,6 @@
                      :url ::web-address)
         :ret nil?)
 
-(defn- root-node-id
-  ([] (root-node-id @current-automation))
-  ([ctx]
-   (:node-id @(:root ctx))))
-
 (defn sel
   "Select elements by selector."
   ([selector] (sel @current-automation selector))
@@ -168,16 +163,16 @@
    (wait :element '()
          (map (fn [id]
                 {:node-id id})
-              (:node-ids (dom/query-selector-all c {:node-id (root-node-id ctx)
-                                                    :selector (selector->string selector)}))))))
+              (:node-ids (dom/query-selector-all c (merge (root ctx)
+                                                          {:selector (selector->string selector)})))))))
 
 (defn sel1
   "Select a single element by selector."
   ([selector] (sel1 @current-automation selector))
   ([{c :connection :as ctx} selector]
    (wait :element {:node-id 0} nil
-         (dom/query-selector c {:node-id (root-node-id ctx)
-                                :selector (selector->string selector)}))))
+         (dom/query-selector c (merge (root ctx)
+                                      {:selector (selector->string selector)})))))
 
 (defn bounding-box
   ([node] (bounding-box @current-automation node))


### PR DESCRIPTION
This may not be the best solution, but it worked for me! Not sure why the root node id kept changing, it may be connected to the fact that I'm trying to test a react app? I tried removing the root atom completely, but then realized that the `wait` in the `to` function was using it.