### PR TITLE
Upgrade Clojure+Java dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
-{:deps {http-kit               {:mvn/version "2.2.0"}
-        cheshire               {:mvn/version "5.8.0"}
-        stylefruits/gniazdo    {:mvn/version "1.0.1"}
-        org.clojure/core.async {:mvn/version "0.4.474"}
+{:deps {http-kit               {:mvn/version "2.3.0"}
+        cheshire               {:mvn/version "5.8.1"}
+        stylefruits/gniazdo    {:mvn/version "1.1.1"}
+        org.clojure/core.async {:mvn/version "0.4.490"}
         com.taoensso/timbre    {:mvn/version "4.10.0"}}}

--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,10 @@
   :license {:name "MIT License"}
   :url "https://github.com/tatut/clj-chrome-devtools"
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [http-kit "2.2.0"]
-                 [cheshire "5.8.0"]
-                 [stylefruits/gniazdo "1.0.1"]
-                 [org.clojure/core.async "0.4.474"]
+                 [http-kit "2.3.0"]
+                 [cheshire "5.8.1"]
+                 [stylefruits/gniazdo "1.1.1"]
+                 [org.clojure/core.async "0.4.490"]
                  [com.taoensso/timbre "4.10.0"]]
   :plugins [[lein-codox "0.10.3"]]
   :codox {:output-path "docs/api"


### PR DESCRIPTION
I personally tend to advocate for keeping deps current as a general practice, but in this case I am specifically motivated to upgrade `stylefruits/gniazdo` because it has an upgraded version of `org.eclipse.jetty.websocket/websocket-client` which includes a fix for [issue #1262][1] which was causing my app to print out WARNING log messages when I use *this* library.

All tests passed when I ran `lein test`.

[1]: https://github.com/eclipse/jetty.project/issues/1262