### PR TITLE
Add timeout to automation/evaluate

### DIFF
--- a/test/clj_chrome_devtools/automation_test.clj
+++ b/test/clj_chrome_devtools/automation_test.clj
@@ -1,0 +1,26 @@
+(ns clj-chrome-devtools.automation-test
+  (:require [clj-chrome-devtools.automation :as a]
+            [clj-chrome-devtools.automation.fixture :refer [create-chrome-fixture]]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test :as t :refer [deftest is testing]]))
+
+(stest/instrument)
+
+(defonce chrome-fixture (create-chrome-fixture))
+(t/use-fixtures :each chrome-fixture)
+
+(deftest evaluate
+  (testing "a call that takes longer than the default timeout should throw an exception"
+    (let [[prior-default-timeout _] (reset-vals! a/default-timeout-ms 100)]
+      (is (thrown-with-msg?
+           RuntimeException
+           #"^Timeout!.+"
+           (a/evaluate "Array(1024 ** 3).fill().map(Math.random).length")))
+      (reset! a/default-timeout-ms prior-default-timeout)))
+  (testing "a call that takes longer than the supplied timeout should throw an exception"
+    (is (thrown-with-msg?
+         RuntimeException
+         #"^Timeout!.+"
+         (a/evaluate @a/current-automation
+                    "Array(1024 ** 3).fill().map(Math.random).length"
+                    100)))))


### PR DESCRIPTION
I maintain [a tool][1] that uses this library and I recently had to
debug an issue wherein the tool would hang in certain circumstances. It
turned out that I was executing a JS expression that was returning too
much data — I didn’t know about [the default 1MB limit][2] and it took
me a good while to figure out what was happening. I’ll be contributing a
different PR to add some logging to hopefully help other people who run
into similar problems, but this PR is focused on adding a timeout to
automation/evaluate. I [did this first][3] in the tool’s code because
(a) it helped me debug the underlying problem by giving my REPL back to
me instead of hanging indefinitely and (b) it just seemed like a better
failure mode than hanging.

Given that this seems like a better way for `evaluate` to work, I
thought I’d offer it as an enhancement to the library.

[1]: https://fundingcircle.github.io/fc4-framework/tool/
[2]: https://git.io/fjDeX
[3]: https://git.io/fjDe1