### PR TITLE
Tweak logging when a conn closes on JVM shutdown

### DIFF
--- a/src/clj_chrome_devtools/impl/connection.clj
+++ b/src/clj_chrome_devtools/impl/connection.clj
@@ -78,12 +78,22 @@
                  ", throwable: " t))))
 
 (defn- on-close [code reason]
-  (log/log (case code 1000 :info :warn)
-           "WebSocket connection closed with status code"
-           code
-           (str "(" (ws-close-status-code->reason code "UNKNOWN") ")")
-           "and reason:"
-           reason))
+  (log/log
+   ; The library that gniazdo wraps (the Jetty WebSocket API/Client) registers a
+   ; JVM shutdown hook to (I think) close the connection when the JVM shuts
+   ; down. This causes the on-close hook to be called during JVM shutdown. Since
+   ; this case (code 1001 and reason "Shutdown") is a normal, uninteresting
+   ; case, we want to use the :info log level. Same for when the code is 1000,
+   ; which is specifically for normal closures. Otherwise, we’ll use :warn
+   ; because the closure would appear to be abnormal.
+   (if (or (= code 1000)
+           (and (= code 1001) (re-seq #"(?i)shutdown" reason)))
+     :info :warn)
+   "WebSocket connection closed with status code"
+   code
+   (str "(" (ws-close-status-code->reason code "UNKNOWN") ")")
+   "and reason:"
+   reason))
 
 (defn- wait-for-remote-debugging-port [host port max-wait-time-ms]
   (let [wait-until (+ (System/currentTimeMillis) max-wait-time-ms)

--- a/src/clj_chrome_devtools/impl/connection.clj
+++ b/src/clj_chrome_devtools/impl/connection.clj
@@ -25,24 +25,6 @@
     (assert c "No current Chrome Devtools connection!")
     c))
 
-(def ws-close-status-code->reason
-  ^{:source "https://tools.ietf.org/html/rfc6455#section-7.4"}
-  {1000 "Normal"
-   1001 "Going away"
-   1002 "Protocol error"
-   1003 "Unsupported"
-   1005 "No status code"
-   1006 "Abnormal"
-   1007 "Unsupported payload"
-   1008 "Policy violation"
-   1009 "Too large"
-   1010 "Mandatory extension"
-   1011 "Server error"
-   1012 "Service restart"
-   1013 "Try again later"
-   1014 "Bad gateway"
-   1015 "TLS handshake fail"})
-
 (defn- parse-json [string]
   (cheshire/parse-string string (comp keyword camel->clojure)))
 
@@ -89,11 +71,7 @@
    (if (or (= code 1000)
            (and (= code 1001) (re-seq #"(?i)shutdown" reason)))
      :info :warn)
-   "WebSocket connection closed with status code"
-   code
-   (str "(" (ws-close-status-code->reason code "UNKNOWN") ")")
-   "and reason:"
-   reason))
+   (format "WebSocket connection closed with status code %s: %s)" code reason)))
 
 (defn- wait-for-remote-debugging-port [host port max-wait-time-ms]
   (let [wait-until (+ (System/currentTimeMillis) max-wait-time-ms)

--- a/test/clj_chrome_devtools/impl/connection_test.clj
+++ b/test/clj_chrome_devtools/impl/connection_test.clj
@@ -57,7 +57,7 @@
         (let [output (join @log)]
           (is (re-seq #".+ERROR.+MessageTooLargeException.+message size.+exceeds maximum size.+"
                       output))
-          (is (re-seq #".+WARN.+WebSocket connection closed with status code 1009 \(Too large\) and reason: Text message size.+exceeds maximum size.+"
+          (is (re-seq #".+WARN.+WebSocket connection closed with status code 1009: Text message size.+exceeds maximum size.+"
                       output)))))
     (testing "specified limit (2MB)"
       (let [conn (make-conn {:max-msg-size-mb (* 1024 1024 2)})
@@ -74,7 +74,7 @@
         (let [output (join @log)]
           (is (re-seq #".+ERROR.+MessageTooLargeException.+message size.+exceeds maximum size.+"
                       output))
-          (is (re-seq #".+WARN.+WebSocket connection closed with status code 1009 \(Too large\) and reason: Text message size.+exceeds maximum size.+"
+          (is (re-seq #".+WARN.+WebSocket connection closed with status code 1009: Text message size.+exceeds maximum size.+"
                       output)))))))
 
 (def test-page
@@ -84,7 +84,7 @@
   (testing "Connection objects should work with (be closed by) with-open"
     (let [conn (make-conn)
           auto (create-automation conn)]
-      (with-open [conn conn]
+      (with-open [_ conn]
         ; Simple validation that the connection works
         (to auto test-page)
         (is (= (map #(text-of auto %)


### PR DESCRIPTION
### 816ac4573: Tweak logging when a conn closes on JVM shutdown

The library that gniazdo wraps (the Jetty WebSocket API/Client)
registers a JVM shutdown hook to (I think) close the connection when the
JVM shuts down. This causes the on-close hook to be called during JVM
shutdown. Currently, this is causing a WARN log message to be emitted
(written to stdout) when the JVM shuts down — even if the WS connection
has been closed beforehand.

Since this case (code 1001 and reason "Shutdown") is a normal,
uninteresting case, it will be better to use the :info log level, so
that in this case the log message will not be output when the JVM shuts
down.

### b413ad6: Simplify and streamline on-close handler

* I realized that there’s no need for this library to maintain its own
  mapping of WS close status codes to reason strings, as I realized that
  the Jetty WS library obviously already has such a mapping, as it
  passes the reason string to the on-close handler. So I removed it.
* Switch to `format` rather than string concatenation for better
  readability.
