### PR TITLE
Adopt lein-tools-deps; update deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.9.0"}
         http-kit               {:mvn/version "2.3.0"}
-        cheshire               {:mvn/version "5.8.1"}
+        cheshire               {:mvn/version "5.9.0"}
         stylefruits/gniazdo    {:mvn/version "1.1.1"}
-        org.clojure/core.async {:mvn/version "0.4.490"}
+        org.clojure/core.async {:mvn/version "0.4.500"}
         com.taoensso/timbre    {:mvn/version "4.10.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.9.0"}
         http-kit               {:mvn/version "2.3.0"}
         cheshire               {:mvn/version "5.9.0"}
-        stylefruits/gniazdo    {:mvn/version "1.1.1"}
+        stylefruits/gniazdo    {:mvn/version "1.1.2"}
         org.clojure/core.async {:mvn/version "0.4.500"}
         com.taoensso/timbre    {:mvn/version "4.10.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:deps {http-kit               {:mvn/version "2.3.0"}
+{:deps {org.clojure/clojure    {:mvn/version "1.9.0"}
+        http-kit               {:mvn/version "2.3.0"}
         cheshire               {:mvn/version "5.8.1"}
         stylefruits/gniazdo    {:mvn/version "1.1.1"}
         org.clojure/core.async {:mvn/version "0.4.490"}

--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,9 @@
   :description "Clojure API for Chrome DevTools remote"
   :license {:name "MIT License"}
   :url "https://github.com/tatut/clj-chrome-devtools"
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [http-kit "2.3.0"]
-                 [cheshire "5.8.1"]
-                 [stylefruits/gniazdo "1.1.1"]
-                 [org.clojure/core.async "0.4.490"]
-                 [com.taoensso/timbre "4.10.0"]]
-  :plugins [[lein-codox "0.10.3"]]
+  :plugins [[lein-codox "0.10.3"]
+            [lein-tools-deps "0.4.5"]]
   :codox {:output-path "docs/api"
-          :metadata {:doc/format :markdown}})
+          :metadata {:doc/format :markdown}}
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  :lein-tools-deps/config {:config-files [:install :user :project]})

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Clojure API for Chrome DevTools remote"
   :license {:name "MIT License"}
   :url "https://github.com/tatut/clj-chrome-devtools"
-  :plugins [[lein-codox "0.10.3"]
+  :plugins [[lein-codox "0.10.7"]
             [lein-tools-deps "0.4.5"]]
   :codox {:output-path "docs/api"
           :metadata {:doc/format :markdown}}

--- a/test/clj_chrome_devtools/impl/connection_test.clj
+++ b/test/clj_chrome_devtools/impl/connection_test.clj
@@ -6,10 +6,10 @@
             [clj-chrome-devtools.impl.util :as util]
             [clojure.java.io :as io]
             [clojure.spec.test.alpha :as stest]
-            [clojure.string :refer [includes? join]]
+            [clojure.string :refer [join]]
             [clojure.test :as t :refer [deftest is testing]]
             [taoensso.timbre :as log])
-  (:import [org.eclipse.jetty.websocket.api WebSocketException]))
+  (:import [java.util.concurrent ExecutionException]))
 
 (stest/instrument)
 
@@ -84,10 +84,10 @@
   (testing "Connection objects should work with (be closed by) with-open"
     (let [conn (make-conn)
           auto (create-automation conn)]
-      (with-open [conn conn]
+      (with-open [_ conn]
         ; Simple validation that the connection works
         (to auto test-page)
         (is (= (map #(text-of auto %)
                     (sel auto "ul#thelist li"))
                '("foo" "bar" "baz"))))
-      (is (thrown-with-msg? WebSocketException #"current state \[CLOSED\]" (to auto test-page))))))
+      (is (thrown-with-msg? ExecutionException #"ClosedChannelException" (to auto test-page))))))


### PR DESCRIPTION
### 545291d: Adopt lein-tools-deps

Before this the dependencies were declared redundantly in two different
places (`project.clj` and `deps.edn`) and these two declarations had to
be kept in sync manually — which was bound to fail (via human error)
sooner or later.

[lein-tools-deps](https://github.com/RickMoynihan/lein-tools-deps) allows us to specify the dependencies in one place while
ensuring that both tools.deps and Leiningen will continue to work with
this project.

### 981c330: Update deps

Except gniazdo; see the following commit.

lein-codox is failing after this change, but I checked and it was
already failing on the prior commit and on master. So that failure would
seem to be unrelated to the upgrade so I see no reason not to upgrade
it.

### ae2a06e: Update gniazdo from 1.1.1 to 1.1.2

As far as I can tell from the [commit log][1], the only notable change
in this update is to upgrade the Jetty websocket-client (JWC) from
9.4.14.v20181114 to 9.4.19.v20190610.

That upgrade seems mostly safe, and necessitated only a minor code
change, and only to the tests; it seems that the JWC changed the
exception that’s thrown when a send-message method is invoked with a
closed connection.

[1]: https://github.com/stalefruits/gniazdo/commits/v1.1.2