### PR TITLE
Further tweak and simplify logging on WS conn close

### DIFF
--- a/src/clj_chrome_devtools/impl/connection.clj
+++ b/src/clj_chrome_devtools/impl/connection.clj
@@ -14,7 +14,6 @@
     (when ws-conn 
       (ws/close ws-conn))))
 
-
 (defn connection? [c]
   (instance? Connection c))
 
@@ -59,19 +58,9 @@
       (log/error "Exception in devtools WebSocket receive, msg: " msg
                  ", throwable: " t))))
 
-(defn- on-close [code reason]
-  (log/log
-   ; The library that gniazdo wraps (the Jetty WebSocket API/Client) registers a
-   ; JVM shutdown hook to (I think) close the connection when the JVM shuts
-   ; down. This causes the on-close hook to be called during JVM shutdown. Since
-   ; this case (code 1001 and reason "Shutdown") is a normal, uninteresting
-   ; case, we want to use the :info log level. Same for when the code is 1000,
-   ; which is specifically for normal closures. Otherwise, we’ll use :warn
-   ; because the closure would appear to be abnormal.
-   (if (or (= code 1000)
-           (and (= code 1001) (re-seq #"(?i)shutdown" reason)))
-     :info :warn)
-   (format "WebSocket connection closed with status code %s: %s)" code reason)))
+(defn- on-close
+  [code reason]
+  (log/info "WebSocket connection closed with status code and reason:" code reason))
 
 (defn- wait-for-remote-debugging-port [host port max-wait-time-ms]
   (let [wait-until (+ (System/currentTimeMillis) max-wait-time-ms)

--- a/test/clj_chrome_devtools/impl/connection_test.clj
+++ b/test/clj_chrome_devtools/impl/connection_test.clj
@@ -57,7 +57,7 @@
         (let [output (join @log)]
           (is (re-seq #".+ERROR.+MessageTooLargeException.+message size.+exceeds maximum size.+"
                       output))
-          (is (re-seq #".+WARN.+WebSocket connection closed with status code 1009: Text message size.+exceeds maximum size.+"
+          (is (re-seq #".+INFO.+WebSocket connection closed with status code and reason: 1009 Text message size.+exceeds maximum size.+"
                       output)))))
     (testing "specified limit (2MB)"
       (let [conn (make-conn {:max-msg-size-mb (* 1024 1024 2)})
@@ -74,7 +74,7 @@
         (let [output (join @log)]
           (is (re-seq #".+ERROR.+MessageTooLargeException.+message size.+exceeds maximum size.+"
                       output))
-          (is (re-seq #".+WARN.+WebSocket connection closed with status code 1009: Text message size.+exceeds maximum size.+"
+          (is (re-seq #".+INFO.+WebSocket connection closed with status code and reason: 1009 Text message size.+exceeds maximum size.+"
                       output)))))))
 
 (def test-page


### PR DESCRIPTION
This is a follow-up to #23 and #19.

I’ve found that even after the changes in #23, I’m still getting WARN log message logged and output when the WS connection closes.

@tatut my apologies for the torrent of Pull Requests. Please let me know if this is all too burdensome and I can focus on using my own fork of the library most of the time and porting improvements back upstream once they’re more proven.

### Deep dive

This time, it’s status code 1006 with reason “Disconnected” — which is
a reasonable case for Jetty WebSocket Client to invoke the on-close
handler that’s set; at this point I think it was just a mistake for me
to try to have *this* library determine when to log a `:warn` record vs
an `:info` record — in other words, to determine what’s “normal” and
what’s “abnormal”. At this point I feel like it’s, generally speaking,
a normal event for these connections to close, even if the closure might
*technically* seem abnormal to the WebSocket Client library. Since
managing WS connections is only a means to an end for *this* library,
rather than the main point, I think this library should just use `:info`
for all WS conn closure events. This should be sufficient for someone
using the library who has a need to debug WS connection issues; all
they’d need to do would be to adjust the level of the Timbre logger
and/or one or more of the Timbre appenders.