### PR TITLE
Avoid blocking IO in go-block

### DIFF
--- a/src/clj_chrome_devtools/automation.clj
+++ b/src/clj_chrome_devtools/automation.clj
@@ -9,7 +9,7 @@
             [clj-chrome-devtools.events :as events]
             [clj-chrome-devtools.impl.connection :as connection]
             [taoensso.timbre :as log]
-            [clojure.core.async :as async :refer [go-loop go <!! <!]]
+            [clojure.core.async :as async :refer [go-loop go thread <!! <!]]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.spec.alpha :as s])
@@ -109,7 +109,7 @@
          ch (events/listen connection :page :frame-stopped-loading)]
      (go-loop [v (<! ch)]
        (when v
-         (let [root (:root (dom/get-document connection {}))]
+         (let [root (:root (<! (thread (dom/get-document connection {}))))]
            (log/trace "Document updated, new root: " root)
            (reset! root-atom root))
          (recur (<! ch))))


### PR DESCRIPTION
Hi, 

I found a subtle bug that all threads will be blocked in the async thread pool. After some investigations by jstack. I found all threads are waiting and the stacks are all including function `dom/get-document`. 

I do not have exact steps to reproduce the dead lock. In my production environment, I will spawn about 10 automations to do some scraping job concurrently. I did a workaround that enlarged the `clojure.core.async.pool-size` to 32 and the dead lock did not happen again after that. So I think this patch can fix it.

References:
https://martintrojer.github.io/clojure/2013/07/07/coreasync-and-blocking-io