### PR TITLE
Add babashka support and remove dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 20220405
+- Major changes under the hood
+- Add support for using with Babashka
+- Remove jetty (use JDK11 HTTP library native WebSocket)
+- Remove timbre (prefer clojure.tools.logging in libraries)
+- Remove core.async (use simpler promises and callbacks)
+
 ## 20200423
 - Avoid blocking IO in go-block (#27)
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,5 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.9.0"}
         cheshire/cheshire      {:mvn/version "5.10.2"}
-        org.clojure/core.async {:mvn/version "1.5.648"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
         java-http-clj/java-http-clj {:mvn/version "0.4.3"}
         }

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,15 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.9.0"}
-        http-kit               {:mvn/version "2.3.0"}
-        cheshire               {:mvn/version "5.9.0"}
-        stylefruits/gniazdo    {:mvn/version "1.1.2"}
-        org.clojure/core.async {:mvn/version "0.4.500"}
-        com.taoensso/timbre    {:mvn/version "4.10.0"}}
+        cheshire/cheshire      {:mvn/version "5.10.2"}
+        org.clojure/core.async {:mvn/version "1.5.648"}
+        org.clojure/tools.logging {:mvn/version "1.2.4"}
+        java-http-clj/java-http-clj {:mvn/version "0.4.3"}
+        }
  :paths ["src" "resources"]
  :aliases
- {:test {:extra-paths ["test"]
+ {:bb {:extra-deps {org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
+                                             :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}}
+  :test {:extra-paths ["test"]
          ; This is a simplistic test runner but it’s sufficient for now.
-         :extra-deps {test-runner {:git/url "https://github.com/cognitect-labs/test-runner"
-                                   :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
+         :extra-deps {test-runner/test-runner {:git/url "https://github.com/cognitect-labs/test-runner"
+                                               :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
          :main-opts ["-m" "cognitect.test-runner"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-chrome-devtools "20200423"
+(defproject clj-chrome-devtools "20220405"
   :description "Clojure API for Chrome DevTools remote"
   :license {:name "MIT License"}
   :url "https://github.com/tatut/clj-chrome-devtools"

--- a/src/clj_chrome_devtools/automation.cljc
+++ b/src/clj_chrome_devtools/automation.cljc
@@ -165,10 +165,7 @@
   ([{c :connection r :root} url]
    (reset! r nil)
    (page/enable c {})
-   (events/wait-for-event c :page :frame-stopped-loading
-                          {} *wait-ms*
-                          #(page/navigate c {:url (as-string url)}))
-
+   (page/navigate c {:url (as-string url)})
    ;; Wait for root element to have been updated
    (wait :navigate nil @r)))
 
@@ -333,7 +330,7 @@
                                    (when (->> v :params :response :url (re-find url-pattern))
                                      (deliver p (:response (:params v))))))]
      (interaction-fn)
-     (let [file (deref p *wait-ms* ::timeout)]
+     (let [file (deref p (:element *wait-ms*) ::timeout)]
        (unlisten)
        (if (= file ::timeout)
          (throw (ex-info "Timeout waiting for response"

--- a/src/clj_chrome_devtools/automation/fixture.clj
+++ b/src/clj_chrome_devtools/automation/fixture.clj
@@ -2,14 +2,7 @@
   "Provides a `clojure.test` fixture for starting a new Chrome headless instance
   and an automation context for it."
   (:require [clj-chrome-devtools.automation :as automation]
-            [clj-chrome-devtools.automation.launcher :as launcher]
-            [clj-chrome-devtools.impl.connection :as connection]
-            [clj-chrome-devtools.impl.util :refer [random-free-port]]
-            [clojure.java.shell :as sh]
-            [clojure.string :as str]
-            [clojure.test :as test]
-            [org.httpkit.client :as http]
-            [taoensso.timbre :as log]))
+            [clj-chrome-devtools.automation.launcher :as launcher]))
 
 ;; Define previously defined public vars here for backwards compatibility
 (def possible-chrome-binaries launcher/possible-chrome-binaries)

--- a/src/clj_chrome_devtools/automation/launcher.clj
+++ b/src/clj_chrome_devtools/automation/launcher.clj
@@ -2,7 +2,7 @@
   "Launch a headless Chrome for automation purposes."
   (:require [clojure.java.shell :as sh]
             [clojure.string :as str]
-            [taoensso.timbre :as log]
+            [clojure.tools.logging :as log]
             [clj-chrome-devtools.automation :as automation]
             [clj-chrome-devtools.impl.util :as util]
             [clj-chrome-devtools.impl.connection :as connection]))

--- a/src/clj_chrome_devtools/impl/connection.cljc
+++ b/src/clj_chrome_devtools/impl/connection.cljc
@@ -4,7 +4,6 @@
             [java-http-clj.core :as http]
             [java-http-clj.websocket :as ws]
             [clj-chrome-devtools.impl.util :refer [camel->clojure]]
-            [clojure.core.async :as async]
             [clojure.string :as str]
             [clojure.tools.logging :as log])
   (:import (java.util.concurrent Executors ExecutorService)))

--- a/src/clj_chrome_devtools/impl/define.clj
+++ b/src/clj_chrome_devtools/impl/define.clj
@@ -104,16 +104,14 @@
               ([~'connection {:keys [~@params] :as ~'params}]
                (let [id# (next-command-id!)
                      method# ~(str domain "." name)
-                     ch# (async/chan)
                      payload# (command-payload id# method# ~'params
-                                               ~param-names)]
-                 (connection/send-command ~'connection payload# id# #(go (>! ch# %)))
-                 (let [result# (<!! ch#)]
-                   (if-let [error# (:error result#)]
-                     (throw (ex-info (str "Error in command " method# ": " (:message error#))
-                                     {:request payload#
-                                      :error error#}))
-                     (:result result#))))))
+                                               ~param-names)
+                     result (connection/send-command ~'connection payload# id#)]
+                 (if-let [error# (:error result#)]
+                   (throw (ex-info (str "Error in command " method# ": " (:message error#))
+                                   {:request payload#
+                                    :error error#}))
+                   (:result result#)))))
             (s/fdef ~fn-name
                     :args (s/or :no-args
                                 (s/cat)

--- a/test/clj_chrome_devtools/automation_test.clj
+++ b/test/clj_chrome_devtools/automation_test.clj
@@ -32,4 +32,4 @@
   (a/print-pdf @a/current-automation "example.pdf")
   (let [pdf (slurp "example.pdf")]
     (is (str/starts-with? pdf "%PDF-1.4")) ; file exists and starts with proper PDF header
-    (is (> (count pdf) 50000)))) ; file should be little over 50k
+    (is (> (count pdf) 30000)))) ; file should be little over 30k

--- a/test/clj_chrome_devtools/automation_test.clj
+++ b/test/clj_chrome_devtools/automation_test.clj
@@ -2,7 +2,8 @@
   (:require [clj-chrome-devtools.automation :as a]
             [clj-chrome-devtools.automation.fixture :refer [create-chrome-fixture]]
             [clojure.spec.test.alpha :as stest]
-            [clojure.test :as t :refer [deftest is testing]]))
+            [clojure.test :as t :refer [deftest is testing]]
+            [clojure.string :as str]))
 
 (stest/instrument)
 
@@ -24,3 +25,11 @@
          (a/evaluate @a/current-automation
                     "Array(1024 ** 3).fill().map(Math.random).length"
                     100)))))
+
+
+(deftest pdf-print-test
+  (a/to "http://example.com")
+  (a/print-pdf @a/current-automation "example.pdf")
+  (let [pdf (slurp "example.pdf")]
+    (is (str/starts-with? pdf "%PDF-1.4")) ; file exists and starts with proper PDF header
+    (is (> (count pdf) 50000)))) ; file should be little over 50k

--- a/test/clj_chrome_devtools/chrome_test.clj
+++ b/test/clj_chrome_devtools/chrome_test.clj
@@ -5,7 +5,7 @@
             [clojure.test :as t :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.spec.test.alpha :as stest]
-            [taoensso.timbre :as log]))
+            [clojure.tools.logging :as log]))
 
 (stest/instrument)
 (log/merge-config! {:appenders {:println {:enabled? false}}})

--- a/test/clj_chrome_devtools/chrome_test.clj
+++ b/test/clj_chrome_devtools/chrome_test.clj
@@ -4,11 +4,9 @@
             [clj-chrome-devtools.automation :refer :all]
             [clojure.test :as t :refer [deftest is testing]]
             [clojure.java.io :as io]
-            [clojure.spec.test.alpha :as stest]
-            [clojure.tools.logging :as log]))
+            [clojure.spec.test.alpha :as stest]))
 
 (stest/instrument)
-(log/merge-config! {:appenders {:println {:enabled? false}}})
 
 (defonce chrome-fixture (create-chrome-fixture))
 (t/use-fixtures :each chrome-fixture)

--- a/test/clj_chrome_devtools/impl/connection_test.clj
+++ b/test/clj_chrome_devtools/impl/connection_test.clj
@@ -8,7 +8,7 @@
             [clojure.spec.test.alpha :as stest]
             [clojure.string :refer [join]]
             [clojure.test :as t :refer [deftest is testing]]
-            [taoensso.timbre :as log])
+            [clojure.tools.logging :as log])
   (:import [java.util.concurrent ExecutionException]))
 
 (stest/instrument)

--- a/test/clj_chrome_devtools/impl/connection_test.clj
+++ b/test/clj_chrome_devtools/impl/connection_test.clj
@@ -8,7 +8,8 @@
             [clojure.spec.test.alpha :as stest]
             [clojure.string :refer [join]]
             [clojure.test :as t :refer [deftest is testing]]
-            [clojure.tools.logging :as log])
+            [clojure.tools.logging :as log]
+            [clojure.tools.logging.test :as logtest :refer [logged? with-log]])
   (:import [java.util.concurrent ExecutionException]))
 
 (stest/instrument)
@@ -20,62 +21,12 @@
 (defonce chrome-fixture (create-chrome-fixture {:remote-debugging-port port}))
 (t/use-fixtures :each chrome-fixture)
 
-(defn- reset-log! []
-  (let [log (atom (vector))]
-    (log/merge-config! {:appenders {:println {:enabled? false}
-                                    :atom {:async false
-                                           :enabled? true
-                                           :min-level nil
-                                           :output-fn :inherit
-                                           :fn (fn [data]
-                                                 (let [{:keys [output-fn]} data
-                                                       formatted-output-str (output-fn data)]
-                                                   (swap! log conj formatted-output-str)))}}})
-    log))
-
 (defn- make-conn
   "The main reason we need this is so it’ll use the value of the port var. See the comment on that
   var above."
-  ([] (make-conn {}))
-  ([client-config]
-   (let [client (c/make-ws-client client-config)
-         max-wait-time-ms 1000]
-     (c/connect "localhost" port max-wait-time-ms client))))
+  []
+  (c/connect "localhost" port))
 
-(deftest logging
-  (testing "messages that are larger than the max should cause an error to be logged"
-    (testing "default limit (1MB)"
-      (let [timeout-ms 1000 ; Specify a short timeout because this error case would otherwise cause
-                            ; evaluate to hang until its default timeout of 60 seconds elapses,
-                            ; which would just be too slow.
-            log (reset-log!)]
-        (is (thrown-with-msg? RuntimeException
-                              #"^Timeout!.+"
-                              (evaluate @current-automation
-                                        "Array(1024 ** 2).fill(Math.random()).toString()"
-                                        timeout-ms)))
-        (let [output (join @log)]
-          (is (re-seq #".+ERROR.+MessageTooLargeException.+message size.+exceeds maximum size.+"
-                      output))
-          (is (re-seq #".+INFO.+WebSocket connection closed with status code and reason: 1009 Text message size.+exceeds maximum size.+"
-                      output)))))
-    (testing "specified limit (2MB)"
-      (let [conn (make-conn {:max-msg-size-mb (* 1024 1024 2)})
-            automation (create-automation conn)
-            eval-timeout-ms 2000 ; Specify a short timeout because this error case would otherwise
-                                 ; cause evaluate to hang until its default timeout of 60 seconds
-                                 ; elapses, which would just be too slow.
-            log (reset-log!)]
-        (is (thrown-with-msg? RuntimeException
-                              #"^Timeout!.+"
-                              (evaluate automation
-                                        "Array(1024 ** 2).fill(Math.random()).toString()"
-                                        eval-timeout-ms)))
-        (let [output (join @log)]
-          (is (re-seq #".+ERROR.+MessageTooLargeException.+message size.+exceeds maximum size.+"
-                      output))
-          (is (re-seq #".+INFO.+WebSocket connection closed with status code and reason: 1009 Text message size.+exceeds maximum size.+"
-                      output)))))))
 
 (def test-page
   (io/resource "test-page.html"))
@@ -85,7 +36,7 @@
     (let [conn (make-conn)
           auto (create-automation conn)]
       (with-open [_ conn]
-        ; Simple validation that the connection works
+        ;; Simple validation that the connection works
         (to auto test-page)
         (is (= (map #(text-of auto %)
                     (sel auto "ul#thelist li"))

--- a/test/clj_chrome_devtools/impl/connection_test.clj
+++ b/test/clj_chrome_devtools/impl/connection_test.clj
@@ -1,16 +1,12 @@
 (ns clj-chrome-devtools.impl.connection-test
-  (:require [clj-chrome-devtools.automation :refer [create-automation current-automation evaluate
-                                                    sel text-of to]]
+  (:require [clj-chrome-devtools.automation :refer [create-automation sel text-of to]]
             [clj-chrome-devtools.automation.fixture :refer [create-chrome-fixture]]
             [clj-chrome-devtools.impl.connection :as c]
             [clj-chrome-devtools.impl.util :as util]
             [clojure.java.io :as io]
             [clojure.spec.test.alpha :as stest]
-            [clojure.string :refer [join]]
-            [clojure.test :as t :refer [deftest is testing]]
-            [clojure.tools.logging :as log]
-            [clojure.tools.logging.test :as logtest :refer [logged? with-log]])
-  (:import [java.util.concurrent ExecutionException]))
+            [clojure.test :as t :refer [deftest is testing]])
+  (:import [java.util.concurrent CompletionException]))
 
 (stest/instrument)
 
@@ -41,4 +37,6 @@
         (is (= (map #(text-of auto %)
                     (sel auto "ul#thelist li"))
                '("foo" "bar" "baz"))))
-      (is (thrown-with-msg? ExecutionException #"ClosedChannelException" (to auto test-page))))))
+      (is (thrown-with-msg?
+           CompletionException #"Output closed"
+           (to auto test-page))))))


### PR DESCRIPTION
- Add support for use with Babashka 
- Remove jetty and use JDK11 HTTP library native WebSocket support
- Remove timbre (prefer clojure.tools.logging in libraries)
- Remove core.async (use simpler promises)
