### PR TITLE
Add option to start Chrome in a certain page

### DIFF
--- a/src/clj_chrome_devtools/automation/launcher.clj
+++ b/src/clj_chrome_devtools/automation/launcher.clj
@@ -45,7 +45,8 @@
                       (when (:headless? options) "--headless")
                       (when (:no-sandbox? options) "--no-sandbox")
                       "--disable-gpu"
-                      (str "--remote-debugging-port=" remote-debugging-port)])]
+                      (str "--remote-debugging-port=" remote-debugging-port)
+                      (when-let [url (:url-to-open options)] (str url))])]
     (.exec (Runtime/getRuntime)
            ^"[Ljava.lang.String;" (into-array String args))))
 

--- a/src/clj_chrome_devtools/impl/connection.cljc
+++ b/src/clj_chrome_devtools/impl/connection.cljc
@@ -130,7 +130,7 @@
                (filter (comp #{"page"} :type))
                (keep :web-socket-debugger-url)
                first)
-      (throw (ex-info "No debuggable pages found"
+      (throw (ex-info "No debuggable pages found. In headless mode, Chrome requires a :url-to-open parameter in options."
                       {:pages pages}))))
 
 #_(defn make-ws-client

--- a/test/clj_chrome_devtools/automation_test.clj
+++ b/test/clj_chrome_devtools/automation_test.clj
@@ -3,11 +3,12 @@
             [clj-chrome-devtools.automation.fixture :refer [create-chrome-fixture]]
             [clojure.spec.test.alpha :as stest]
             [clojure.test :as t :refer [deftest is testing]]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.java.io :as io]))
 
 (stest/instrument)
 
-(defonce chrome-fixture (create-chrome-fixture))
+(defonce chrome-fixture (create-chrome-fixture {:url-to-open (str (io/resource "test-page.html"))}))
 (t/use-fixtures :each chrome-fixture)
 
 (deftest evaluate

--- a/test/clj_chrome_devtools/chrome_test.clj
+++ b/test/clj_chrome_devtools/chrome_test.clj
@@ -8,11 +8,11 @@
 
 (stest/instrument)
 
-(defonce chrome-fixture (create-chrome-fixture))
-(t/use-fixtures :each chrome-fixture)
-
 (def test-page
   (io/resource "test-page.html"))
+
+(defonce chrome-fixture (create-chrome-fixture {:url-to-open (str test-page)}))
+(t/use-fixtures :each chrome-fixture)
 
 (deftest simple-page-load
   (to test-page)

--- a/test/clj_chrome_devtools/impl/connection_test.clj
+++ b/test/clj_chrome_devtools/impl/connection_test.clj
@@ -14,7 +14,8 @@
 ;; pass the same port number to c/connect.
 (defonce port (util/random-free-port))
 
-(defonce chrome-fixture (create-chrome-fixture {:remote-debugging-port port}))
+(defonce chrome-fixture (create-chrome-fixture {:remote-debugging-port port
+                                                :url-to-open (io/resource "test-page.html")}))
 (t/use-fixtures :each chrome-fixture)
 
 (defn- make-conn


### PR DESCRIPTION
Seems that in headless mode, initially there are no debuggable pages so the initial hookup doesn't work. When not using headless mode it still works. At least on my machine, the automated tests failed on master, so effect of this fix should be easy to replicate.

Adding a new option to launch directly to a page adds a workaround for this.