### PR TITLE
Bugfix: clj-chrome-devtools.automation/click-navigate

### DIFF
--- a/src/clj_chrome_devtools/events.clj
+++ b/src/clj_chrome_devtools/events.clj
@@ -64,4 +64,4 @@
   ([connection domain event timeout-ms body]
    `(wait-for-event ~connection ~domain ~event {} ~timeout-ms
                     (fn []
-                      ~@body))))
+                      ~body))))


### PR DESCRIPTION
`clj-chrome-devtools.automation/click-navigate` was not working since `clj-chrome-devtools.events/with-event-wait` expanded the `body` to `(clojure.core/fn [] click ctx node)`.

```clojure
  (macroexpand
   '(clj-chrome-devtools.events/with-event-wait c :page :frame-stopped-loading
      (click ctx node)))

  '(clj-chrome-devtools.events/wait-for-event
    c
    :page
    :frame-stopped-loading
    {}
    clj-chrome-devtools.events/default-wait-ms
    (clojure.core/fn [] click ctx node))
```

@tatut thanks a lot for creating this awesome library :partying_face: It's great that we can use a Clojure library instead of Puppeteer. I found this little bug today when I first tried to use the `click-navigate` function. It is the only place where `clj-chrome-devtools.events/wait-for-event` is used in the library. But people may already be using it somewhere else. However, I would prefer the breakage here since wrapping the body in an extra `list` (or similar) would be strange. 